### PR TITLE
fixed typo in requirements.txt - plotly had only one equals sign

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ loky==3.5.3
 matplotlib==3.10.1
 numpy==2.2.5
 pandas==2.2.3
-plotly=6.0.1
+plotly==6.0.1
 pytz==2025.2
 requests==2.32.3
 scikit-learn==1.6.1


### PR DESCRIPTION
requirements.txt had a minor typo:

```
plotly=6.0.1
``` 
instead of 

```
plotly==6.0.1
```